### PR TITLE
fix(getHTML): missing an includeSelectorTag option fo element command

### DIFF
--- a/lib/commands/property/getHTML.js
+++ b/lib/commands/property/getHTML.js
@@ -3,9 +3,9 @@
 const findElement = require('../../helpers/findElement');
 
 module.exports = (browser) => {
-    browser.addCommand('getHTML', async function(selector) {
+    browser.addCommand('getHTML', async function(selector, includeSelectorTag = true) {
         const elem = await findElement(this, selector);
 
-        return elem.getHTML();
+        return elem.getHTML(includeSelectorTag);
     });
 };

--- a/test/lib/commands/property/getHTML.js
+++ b/test/lib/commands/property/getHTML.js
@@ -30,7 +30,7 @@ describe('"getHTML" command', () => {
         assert.calledOnceWithExactly(findElement, browser, '.some-selector');
     });
 
-    it('should call "getHTML" on browser element with passed selector', async () => {
+    it('should call "getHTML" on browser element with passed arguments', async () => {
         const browser = mkBrowser_();
         const element = mkElement_();
 
@@ -39,6 +39,18 @@ describe('"getHTML" command', () => {
 
         await browser.getHTML('.some-selector');
 
-        assert.calledOnceWithExactly(element.getHTML);
+        assert.calledOnceWithExactly(element.getHTML, true);
+    });
+
+    it('should call "getHTML" on browser element with passed includeSelectorTag option', async () => {
+        const browser = mkBrowser_();
+        const element = mkElement_();
+
+        findElement.withArgs(browser, '.some-selector').resolves(element);
+        addGetHTML(browser);
+
+        await browser.getHTML('.some-selector', false);
+
+        assert.calledOnceWithExactly(element.getHTML, false);
     });
 });


### PR DESCRIPTION
getHTML command can take option about including/excluding the selector element tag - https://webdriver.io/docs/api/element/getHTML/