### PR TITLE
fix: overwrite w3c button up/down command on mobiles

### DIFF
--- a/lib/commands/mobile/swipe.js
+++ b/lib/commands/mobile/swipe.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const _ = require('lodash');
+const getPerformActionId = require('../../helpers/getPerformActionId');
 const findElement = require('../../helpers/findElement');
 
 module.exports = (browser) => {
-    browser.addCommand('swipe', async function(selector, xOffset, yOffset, speed) {
+    const validateParams = (selector, xOffset, yOffset, speed) => {
         if (typeof selector === 'number') {
             throw new TypeError(
                 'Method "swipe" does not implement the functionality "swipe(xspeed, yspeed)"' +
@@ -17,9 +18,36 @@ module.exports = (browser) => {
                 'Arguments "xOffset", "yOffset" and "speed" must be a numbers'
             );
         }
+    };
 
-        const elem = await findElement(this, selector);
+    if (browser.isW3C) {
+        browser.addCommand('swipe', async function(selector, xOffset, yOffset, speed) {
+            validateParams(selector, xOffset, yOffset, speed);
 
-        return browser.touchFlick(xOffset, yOffset, elem.elementId, speed);
-    });
+            const elem = await findElement(this, selector);
+
+            // Computing swipe duration by swipe distance and speed. Speed is measured in px/sec, hence we need to * 1000
+            const moveDuration = Math.hypot(xOffset, yOffset) / speed * 1000;
+
+            return this.performActions([{
+                type: 'pointer',
+                id: getPerformActionId(browser),
+                parameters: {pointerType: 'touch'},
+                actions: [
+                    {type: 'pointerMove', duration: 0, origin: elem, x: 0, y: 0},
+                    {type: 'pointerDown', button: 0},
+                    {type: 'pointerMove', duration: moveDuration, origin: elem, x: xOffset, y: yOffset},
+                    {type: 'pointerUp', button: 0}
+                ]
+            }]);
+        });
+    } else {
+        browser.addCommand('swipe', async function(selector, xOffset, yOffset, speed) {
+            validateParams(selector, xOffset, yOffset, speed);
+
+            const elem = await findElement(this, selector);
+
+            return browser.touchFlick(xOffset, yOffset, elem.elementId, speed);
+        });
+    }
 };

--- a/lib/commands/mobile/touch.js
+++ b/lib/commands/mobile/touch.js
@@ -1,13 +1,31 @@
 'use strict';
 
 const findElement = require('../../helpers/findElement');
+const getPerformActionId = require('../../helpers/getPerformActionId');
+const {LONG_CLICK_DURATION, CLICK_DURATION} = require('../../constants');
 
 module.exports = (browser) => {
-    browser.addCommand('touch', async function(selector, longClick = false) {
-        const touchCommand = longClick ? 'touchLongClick' : 'touchClick';
+    if (browser.isW3C) {
+        browser.addCommand('touch', async function(selector, longClick = false) {
+            return this.performActions([{
+                type: 'pointer',
+                id: getPerformActionId(browser),
+                parameters: {pointerType: 'touch'},
+                actions: [
+                    {type: 'pointerMove', duration: 0, origin: await findElement(this, selector), x: 0, y: 0},
+                    {type: 'pointerDown', button: 0},
+                    {type: 'pause', duration: longClick ? LONG_CLICK_DURATION : CLICK_DURATION},
+                    {type: 'pointerUp', button: 0}
+                ]
+            }]);
+        });
+    } else {
+        browser.addCommand('touch', async function(selector, longClick = false) {
+            const touchCommand = longClick ? 'touchLongClick' : 'touchClick';
 
-        const elem = await findElement(this, selector);
+            const elem = await findElement(this, selector);
 
-        return this[touchCommand](elem.elementId);
-    });
+            return this[touchCommand](elem.elementId);
+        });
+    }
 };

--- a/lib/commands/protocol/buttonDown.js
+++ b/lib/commands/protocol/buttonDown.js
@@ -4,11 +4,11 @@ const getMouseButtonNameNumber = require('../../helpers/getMouseButtonNameNumber
 const getPerformActionId = require('../../helpers/getPerformActionId');
 
 module.exports = (browser) => {
-    if (!browser.isW3C || browser.buttonDown) {
+    if (!browser.isW3C) {
         return;
     }
 
-    browser.addCommand('buttonDown', function(button) {
+    const commandFn = function(button) {
         return this.performActions([{
             type: 'pointer',
             id: getPerformActionId(browser),
@@ -17,5 +17,13 @@ module.exports = (browser) => {
                 {type: 'pointerDown', button: getMouseButtonNameNumber(button)}
             ]
         }]);
-    });
+    };
+
+    if (!browser.buttonDown) {
+        browser.addCommand('buttonDown', commandFn);
+    } else {
+        browser.overwriteCommand('buttonDown', function(_, button) {
+            return commandFn.call(this, button);
+        });
+    }
 };

--- a/lib/commands/protocol/buttonUp.js
+++ b/lib/commands/protocol/buttonUp.js
@@ -4,11 +4,11 @@ const getMouseButtonNameNumber = require('../../helpers/getMouseButtonNameNumber
 const getPerformActionId = require('../../helpers/getPerformActionId');
 
 module.exports = (browser) => {
-    if (!browser.isW3C || browser.buttonUp) {
+    if (!browser.isW3C) {
         return;
     }
 
-    browser.addCommand('buttonUp', function(button) {
+    const commandFn = function(button) {
         return this.performActions([{
             type: 'pointer',
             id: getPerformActionId(browser),
@@ -17,5 +17,13 @@ module.exports = (browser) => {
                 {type: 'pointerUp', button: getMouseButtonNameNumber(button)}
             ]
         }]);
-    });
+    };
+
+    if (!browser.buttonUp) {
+        browser.addCommand('buttonUp', commandFn);
+    } else {
+        browser.overwriteCommand('buttonUp', function(_, button) {
+            return commandFn.call(this, button);
+        });
+    }
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,5 +2,7 @@
 
 module.exports = {
     DEFAULT_SPEED: 100,
-    DEFAULT_OFFSET: 100
+    DEFAULT_OFFSET: 100,
+    LONG_CLICK_DURATION: 500,
+    CLICK_DURATION: 50
 };

--- a/test/lib/commands/mobile/swipe.js
+++ b/test/lib/commands/mobile/swipe.js
@@ -4,13 +4,15 @@ const proxyquire = require('proxyquire');
 const {mkBrowser_, mkElement_} = require('../../../utils');
 
 describe('"swipe" command', () => {
-    let browser, findElement, addSwipe;
+    let browser, findElement, addSwipe, getPerformActionId;
 
     beforeEach(() => {
         browser = mkBrowser_();
         findElement = sinon.stub().resolves(mkElement_());
+        getPerformActionId = sinon.stub().returns('some-id');
         addSwipe = proxyquire('lib/commands/mobile/swipe', {
-            '../../helpers/findElement': findElement
+            '../../helpers/findElement': findElement,
+            '../../helpers/getPerformActionId': getPerformActionId
         });
     });
 
@@ -55,8 +57,9 @@ describe('"swipe" command', () => {
         assert.calledOnceWithExactly(findElement, browser, '.some-selector');
     });
 
-    it('should call "touchFlick" with offsets, found element id and speed', async () => {
+    it('should call "touchFlick" with offsets, found element id and speed in non W3C mode', async () => {
         const browser = mkBrowser_();
+        browser.isW3C = false;
         const element = mkElement_({id: 123});
 
         findElement.withArgs(browser, '.some-selector').resolves(element);
@@ -65,5 +68,29 @@ describe('"swipe" command', () => {
         await browser.swipe('.some-selector', 100, 200, 300);
 
         assert.calledOnceWithExactly(browser.touchFlick, 100, 200, 123, 300);
+    });
+
+    it('should call performActions in W3C mode', async () => {
+        const browser = mkBrowser_();
+        browser.isW3C = true;
+        const element = mkElement_({id: 123});
+
+        getPerformActionId.withArgs(browser).returns('some-pointer-id');
+        findElement.withArgs(browser, '.some-selector').resolves(element);
+        addSwipe(browser);
+
+        await browser.swipe('.some-selector', 100, 0, 100);
+
+        assert.calledOnceWithExactly(browser.performActions, [{
+            type: 'pointer',
+            id: getPerformActionId(browser),
+            parameters: {pointerType: 'touch'},
+            actions: [
+                {type: 'pointerMove', duration: 0, origin: element, x: 0, y: 0},
+                {type: 'pointerDown', button: 0},
+                {type: 'pointerMove', duration: 1000, origin: element, x: 100, y: 0},
+                {type: 'pointerUp', button: 0}
+            ]
+        }]);
     });
 });

--- a/test/lib/commands/mobile/touch.js
+++ b/test/lib/commands/mobile/touch.js
@@ -2,55 +2,118 @@
 
 const proxyquire = require('proxyquire');
 const {mkBrowser_, mkElement_} = require('../../../utils');
+const {LONG_CLICK_DURATION, CLICK_DURATION} = require('../../../../lib/constants');
 
 describe('"touch" command', () => {
-    let browser, findElement, addTouch;
+    let browser, findElement, addTouch, getPerformActionId;
 
     beforeEach(() => {
         browser = mkBrowser_();
         findElement = sinon.stub().resolves(mkElement_());
+        getPerformActionId = sinon.stub().returns('some-id');
         addTouch = proxyquire('lib/commands/mobile/touch', {
-            '../../helpers/findElement': findElement
+            '../../helpers/findElement': findElement,
+            '../../helpers/getPerformActionId': getPerformActionId
         });
     });
 
     afterEach(() => sinon.restore());
 
-    it('should add "touch" command', () => {
-        addTouch(browser);
+    for (const isW3C of [false, true]) {
+        describe(`in${isW3C ? '' : ' non'} W3C mode`, () => {
+            beforeEach(() => {
+                browser.isW3C = isW3C;
+            });
 
-        assert.calledOnceWithExactly(browser.addCommand, 'touch', sinon.match.func);
+            it('should add "touch" command', () => {
+                addTouch(browser);
+
+                assert.calledOnceWithExactly(browser.addCommand, 'touch', sinon.match.func);
+            });
+
+            it('should get element by passed selector', async () => {
+                addTouch(browser);
+
+                await browser.touch('.some-selector');
+
+                assert.calledOnceWithExactly(findElement, browser, '.some-selector');
+            });
+        });
+    }
+
+    describe('in non W3C mode', () => {
+        beforeEach(() => {
+            browser.isW3C = false;
+        });
+
+        it('should call "touchClick" with element id if "longClick" param is not passed', async () => {
+            const element = mkElement_({id: 123});
+
+            findElement.withArgs(browser, '.some-selector').resolves(element);
+            addTouch(browser);
+
+            await browser.touch('.some-selector');
+
+            assert.calledOnceWithExactly(browser.touchClick, 123);
+        });
+
+        it('should call "touchLongClick" with element id if "longClick" param is passed as truthy', async () => {
+            const element = mkElement_({id: 123});
+
+            findElement.withArgs(browser, '.some-selector').resolves(element);
+            addTouch(browser);
+
+            await browser.touch('.some-selector', true);
+
+            assert.calledOnceWithExactly(browser.touchLongClick, 123);
+        });
     });
 
-    it('should get element by passed selector', async () => {
-        addTouch(browser);
+    describe('in W3C mode', () => {
+        beforeEach(() => {
+            browser.isW3C = true;
+        });
 
-        await browser.touch('.some-selector');
+        it('should call performActions with regular click duration', async () => {
+            const element = mkElement_({id: 123});
 
-        assert.calledOnceWithExactly(findElement, browser, '.some-selector');
-    });
+            findElement.withArgs(browser, '.some-selector').resolves(element);
+            addTouch(browser);
 
-    it('should call "touchClick" with element id if "longClick" param is not passed', async () => {
-        const browser = mkBrowser_();
-        const element = mkElement_({id: 123});
+            await browser.touch('.some-selector');
 
-        findElement.withArgs(browser, '.some-selector').resolves(element);
-        addTouch(browser);
+            assert.calledOnceWithExactly(browser.performActions, [{
+                type: 'pointer',
+                id: 'some-id',
+                parameters: {pointerType: 'touch'},
+                actions: [
+                    {type: 'pointerMove', duration: 0, origin: element, x: 0, y: 0},
+                    {type: 'pointerDown', button: 0},
+                    {type: 'pause', duration: CLICK_DURATION},
+                    {type: 'pointerUp', button: 0}
+                ]
+            }]);
+        });
 
-        await browser.touch('.some-selector');
+        it('should call performActions with long click duration if "longClick" is set', async () => {
+            const element = mkElement_({id: 123});
 
-        assert.calledOnceWithExactly(browser.touchClick, 123);
-    });
+            findElement.withArgs(browser, '.some-selector').resolves(element);
+            addTouch(browser);
 
-    it('should call "touchLongClick" with element id if "longClick" param is passed as truthy', async () => {
-        const browser = mkBrowser_();
-        const element = mkElement_({id: 123});
+            await browser.touch('.some-selector', true);
 
-        findElement.withArgs(browser, '.some-selector').resolves(element);
-        addTouch(browser);
-
-        await browser.touch('.some-selector', true);
-
-        assert.calledOnceWithExactly(browser.touchLongClick, 123);
+            assert.calledOnceWithExactly(browser.performActions, [{
+                type: 'pointer',
+                id: 'some-id',
+                parameters: {pointerType: 'touch'},
+                actions: [
+                    {type: 'pointerMove', duration: 0, origin: element, x: 0, y: 0},
+                    {type: 'pointerDown', button: 0},
+                    {type: 'pause', duration: LONG_CLICK_DURATION},
+                    {type: 'pointerUp', button: 0}
+                ]
+            }]);
+        });
     });
 });


### PR DESCRIPTION
### Подробности

- в [hermione-wdio-migrator](https://github.com/gemini-testing/hermione-wdio-migrator/blob/b784cd767fb6255057afe79c87bf1e2ede05e12e/lib/commands/protocol/buttonDown.js#L7) перед добавлением команды сначала выполняется проверка, не существует ли такая команда, а если существует — то патч не применяется
- в [webdriver](https://github.com/webdriverio/webdriverio/blob/7b8319ff91f331683bb613012aa3ffc10824d8df/packages/webdriver/src/utils.ts#L180) исключительно для мобильных браузеров даже в протокле webdriver на инстансе браузера задаются методы и webdriver, и jsonwire, даже если браузер на самом деле не поддерживает такие команды
- это приводит к тому, что wdio-migrator не применяет патч, команда остается jsonwire, который падает из-за отсутствия поддержки со стороны браузера

### Что сделано?

- Исправлена проблема cannot call non-W3C command in W3C mode в современных версиях chrome-phone

### Принятые решения

- Перезаписывать команды `buttonUp` и `buttonDown`, даже если они уже есть в браузере, если находимся в режиме W3C

### Как я тестировал?

Запускал пропатченную версию на проекте с тестами, которые ранее падали